### PR TITLE
Make Cred Offer manual

### DIFF
--- a/charts/bpa/templates/acapy_deployment.yaml
+++ b/charts/bpa/templates/acapy_deployment.yaml
@@ -86,13 +86,13 @@ spec:
             httpGet:
               path: /status/live
               port: 8031
-            initialDelaySeconds: 45
+            initialDelaySeconds: 90
             periodSeconds: 3
           readinessProbe:
             httpGet:
               path: /status/ready
               port: 8031
-            initialDelaySeconds: 20
+            initialDelaySeconds: 60
             periodSeconds: 10    
           volumeMounts:
           - name: config

--- a/charts/bpa/templates/bpa_deployment.yaml
+++ b/charts/bpa/templates/bpa_deployment.yaml
@@ -48,13 +48,13 @@ spec:
             httpGet:
               path: /health/readiness
               port: 8080
-            initialDelaySeconds: 20
+            initialDelaySeconds: 90
             periodSeconds: 10  
           livenessProbe:
             httpGet:
               path: /health
               port: 8080
-            initialDelaySeconds: 30
+            initialDelaySeconds: 60
             periodSeconds: 20   
           env:
             - name: POSTGRES_PASSWORD

--- a/charts/bpa/values.yaml
+++ b/charts/bpa/values.yaml
@@ -225,7 +225,7 @@ acapy:
     repository: bcgovimages/aries-cloudagent
     pullPolicy: IfNotPresent
     # --  Overrides the image tag whose default is the chart appVersion.
-    tag: py36-1.16-1_0.7.2-rc0
+    tag: py36-1.16-1_0.7.1
 
   adminURLApiKey: 2f9729eef0be49608c1cffd49ee3cc4a
 
@@ -317,9 +317,10 @@ acapy:
 
   staticArgs:
     autoAcceptInvites: true
-    autoRespondMessages: false
     autoAcceptRequests: false
-    autoRespondCredentialProposal: true
+    autoRespondMessages: false
+    autoRespondCredentialProposal: false
+    autoRespondCredentialOffer: false
     autoRespondCredentialRequest: true
     autoRespondPresentationProposal: true
     autoRespondPresentationRequest: false
@@ -329,7 +330,7 @@ acapy:
     autoProvision: true
     monitorPing: true
     publicInvites: true
-    logLevel: warning
+    logLevel: info
 
 postgresql:
   # --  PostgreSQL service configuration


### PR DESCRIPTION
need to rollback to acapy 0.7.1, issues with connections on openshift?
adding longer delays on acapy and bpa rollout, fewer restarts this way.

Signed-off-by: Jason Sherman <jsherman@parcsystems.ca>